### PR TITLE
Switch `value_t` to be `uintptr_t`.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -12,7 +12,9 @@
 #ifndef HATTRIE_COMMON_H
 #define HATTRIE_COMMON_H
 
-typedef unsigned long value_t;
+#include "pstdint.h"
+
+typedef uintptr_t value_t;
 
 #endif
 


### PR DESCRIPTION
This allows `value_t` to be 64-bit on 64-bit architectures where `unsigned long` is still 32-bit.

The main reason I want to do this is to guarantee the ability to store pointers to other objects inside a hat-trie.

I realize this violates some of the cache locality that hat-tries provide, but I need store store a bundle of records at the end of the hat-trie and this seems like the most efficient means to achieve it. I can cast my pointer to a `value_t` and still be safe knowing I have an appropriately sized integer on the other size.

On Linux, this should make no difference at all since sizeof(unsigned long) == sizeof(size_t).
