### PR TITLE
Ahtable load save

### DIFF
--- a/src/ahtable.c
+++ b/src/ahtable.c
@@ -51,28 +51,24 @@ ahtable_t* ahtable_create_n(size_t n)
     return table;
 }
 
-void ahtable_save(ahtable_t* table, FILE* fd)
+void ahtable_save(const ahtable_t* table, FILE* fd)
 {
     if (table == NULL) return;
-
-    assert(sizeof(unsigned long long) == 8);
 
     /* Store table metadata as 64-bit network-ordered (big-endian) values so
      * that architectures with larger capacity can take advantage of size.
      */
-    unsigned long long n = htobe64(table->n);
-    fwrite(&n, sizeof(unsigned long long), 1, fd);
+    uint64_t n = htobe64(table->n);
+    fwrite(&n, sizeof(uint64_t), 1, fd);
 
-    unsigned long long m = htobe64(table->m);
-    fwrite(&m, sizeof(unsigned long long), 1, fd);
+    uint64_t m = htobe64(table->m);
+    fwrite(&m, sizeof(uint64_t), 1, fd);
 
-    unsigned long long max_m = htobe64(table->max_m);
-    fwrite(&max_m, sizeof(unsigned long long), 1, fd);
+    uint64_t max_m = htobe64(table->max_m);
+    fwrite(&max_m, sizeof(uint64_t), 1, fd);
 
-    assert(sizeof(uint8_t) == 1);
     fwrite(&table->flag, sizeof(uint8_t), 1, fd);
 
-    assert(sizeof(unsigned char) == 1);
     fwrite(&table->c0, sizeof(unsigned char), 1, fd);
     fwrite(&table->c1, sizeof(unsigned char), 1, fd);
 
@@ -91,11 +87,10 @@ void ahtable_save(ahtable_t* table, FILE* fd)
  * not be 64-bit. As long as the loaded value fits inside size_t, we're good.
  * Returns 0 if the value didn't fit, 1 otherwise.
  */
-uint8_t read_u64bit_to_size_t(size_t* dest, FILE* fd)
+static uint8_t read_u64bit_to_size_t(size_t* dest, FILE* fd)
 {
-    unsigned long long value;
-    assert(sizeof(unsigned long long) == 8);
-    fread(&value, sizeof(unsigned long long), 1, fd);
+    uint64_t value;
+    fread(&value, sizeof(uint64_t), 1, fd);
     if (value > (size_t)-1) {
         printf("Unable to load 64-bit data from file\n");
         return 0;
@@ -115,10 +110,8 @@ ahtable_t* ahtable_load(FILE* fd)
 
     if (!read_u64bit_to_size_t(&table->max_m, fd)) return NULL;
 
-    assert(sizeof(uint8_t) == 1);
     fread(&table->flag, sizeof(uint8_t), 1, fd);
 
-    assert(sizeof(unsigned char) == 1);
     fread(&table->c0, sizeof(unsigned char), 1, fd);
     fread(&table->c1, sizeof(unsigned char), 1, fd);
 

--- a/src/ahtable.c
+++ b/src/ahtable.c
@@ -10,6 +10,7 @@
 #include "ahtable.h"
 #include "misc.h"
 #include "murmurhash3.h"
+#include "portable_endian.h"
 #include <assert.h>
 #include <string.h>
 
@@ -50,6 +51,90 @@ ahtable_t* ahtable_create_n(size_t n)
     return table;
 }
 
+void ahtable_save(ahtable_t* table, FILE* fd)
+{
+    if (table == NULL) return;
+
+    assert(sizeof(unsigned long long) == 8);
+
+    /* Store table metadata as 64-bit network-ordered (big-endian) values so
+     * that architectures with larger capacity can take advantage of size.
+     */
+    unsigned long long n = htobe64(table->n);
+    fwrite(&n, sizeof(unsigned long long), 1, fd);
+
+    unsigned long long m = htobe64(table->m);
+    fwrite(&m, sizeof(unsigned long long), 1, fd);
+
+    unsigned long long max_m = htobe64(table->max_m);
+    fwrite(&max_m, sizeof(unsigned long long), 1, fd);
+
+    assert(sizeof(uint8_t) == 1);
+    fwrite(&table->flag, sizeof(uint8_t), 1, fd);
+
+    assert(sizeof(unsigned char) == 1);
+    fwrite(&table->c0, sizeof(unsigned char), 1, fd);
+    fwrite(&table->c1, sizeof(unsigned char), 1, fd);
+
+    size_t i;
+    uint32_t slot_size;
+    for (i = 0; i < table->n; ++i) {
+        slot_size = htobe32(table->slot_sizes[i]);
+        fwrite(&slot_size, sizeof(uint32_t), 1, fd);
+        if(table->slot_sizes[i] > 0) {
+            fwrite(table->slots[i], sizeof(unsigned char), table->slot_sizes[i], fd);
+        }
+    }
+}
+
+/* Loads a 64-bit value from disk and casts it into a size_t, which may or may
+ * not be 64-bit. As long as the loaded value fits inside size_t, we're good.
+ * Returns 0 if the value didn't fit, 1 otherwise.
+ */
+uint8_t read_u64bit_to_size_t(size_t* dest, FILE* fd)
+{
+    unsigned long long value;
+    assert(sizeof(unsigned long long) == 8);
+    fread(&value, sizeof(unsigned long long), 1, fd);
+    if (value > (size_t)-1) {
+        printf("Unable to load 64-bit data from file\n");
+        return 0;
+    } else {
+        *dest = (size_t)be64toh(value);
+        return 1;
+    }
+}
+
+ahtable_t* ahtable_load(FILE* fd)
+{
+    size_t n;
+    if (!read_u64bit_to_size_t(&n, fd)) return NULL;
+    ahtable_t* table = ahtable_create_n(n);
+
+    if (!read_u64bit_to_size_t(&table->m, fd)) return NULL;
+
+    if (!read_u64bit_to_size_t(&table->max_m, fd)) return NULL;
+
+    assert(sizeof(uint8_t) == 1);
+    fread(&table->flag, sizeof(uint8_t), 1, fd);
+
+    assert(sizeof(unsigned char) == 1);
+    fread(&table->c0, sizeof(unsigned char), 1, fd);
+    fread(&table->c1, sizeof(unsigned char), 1, fd);
+
+    size_t i;
+    uint32_t slot_size;
+    for (i = 0; i < table->n; ++i) {
+        fread(&slot_size, sizeof(uint32_t), 1, fd);
+        table->slot_sizes[i] = be32toh(slot_size);
+        if(table->slot_sizes[i] > 0) {
+            table->slots[i] = malloc_or_die(table->slot_sizes[i]);
+            fread(table->slots[i], sizeof(unsigned char), table->slot_sizes[i], fd);
+        }
+    }
+
+    return table;
+}
 
 void ahtable_free(ahtable_t* table)
 {

--- a/src/ahtable.h
+++ b/src/ahtable.h
@@ -47,6 +47,7 @@ extern "C" {
 
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdio.h>
 #include "pstdint.h"
 #include "common.h"
 
@@ -73,6 +74,9 @@ extern const size_t ahtable_initial_size;
 ahtable_t* ahtable_create   (void);         // Create an empty hash table.
 ahtable_t* ahtable_create_n (size_t n);     // Create an empty hash table, with
                                             //  n slots reserved.
+
+ahtable_t* ahtable_load     (FILE* fd);               // Load a hash table from a file handle.
+void       ahtable_save     (ahtable_t* T, FILE* fd); // Save a hash table to a file handle.
 
 void       ahtable_free   (ahtable_t*);       // Free all memory used by a table.
 void       ahtable_clear  (ahtable_t*);       // Remove all entries.

--- a/src/ahtable.h
+++ b/src/ahtable.h
@@ -76,7 +76,7 @@ ahtable_t* ahtable_create_n (size_t n);     // Create an empty hash table, with
                                             //  n slots reserved.
 
 ahtable_t* ahtable_load     (FILE* fd);               // Load a hash table from a file handle.
-void       ahtable_save     (ahtable_t* T, FILE* fd); // Save a hash table to a file handle.
+void       ahtable_save     (const ahtable_t* T, FILE* fd); // Save a hash table to a file handle.
 
 void       ahtable_free   (ahtable_t*);       // Free all memory used by a table.
 void       ahtable_clear  (ahtable_t*);       // Remove all entries.

--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -1,0 +1,115 @@
+// "License": Public Domain
+// I, Mathias PanzenbÃ¶ck, place this file hereby into the public domain. Use it at your own risk for whatever you like.
+
+#ifndef PORTABLE_ENDIAN_H__
+#define PORTABLE_ENDIAN_H__
+
+#if (defined(_WIN16) || defined(_WIN32) || defined(_WIN64)) && !defined(__WINDOWS__)
+
+# define __WINDOWS__
+
+#endif
+
+#if defined(__linux__) || defined(__CYGWIN__)
+
+# include <endian.h>
+
+#elif defined(__APPLE__)
+
+# include <libkern/OSByteOrder.h>
+
+# define htobe16(x) OSSwapHostToBigInt16(x)
+# define htole16(x) OSSwapHostToLittleInt16(x)
+# define be16toh(x) OSSwapBigToHostInt16(x)
+# define le16toh(x) OSSwapLittleToHostInt16(x)
+ 
+# define htobe32(x) OSSwapHostToBigInt32(x)
+# define htole32(x) OSSwapHostToLittleInt32(x)
+# define be32toh(x) OSSwapBigToHostInt32(x)
+# define le32toh(x) OSSwapLittleToHostInt32(x)
+ 
+# define htobe64(x) OSSwapHostToBigInt64(x)
+# define htole64(x) OSSwapHostToLittleInt64(x)
+# define be64toh(x) OSSwapBigToHostInt64(x)
+# define le64toh(x) OSSwapLittleToHostInt64(x)
+
+# define __BYTE_ORDER    BYTE_ORDER
+# define __BIG_ENDIAN    BIG_ENDIAN
+# define __LITTLE_ENDIAN LITTLE_ENDIAN
+# define __PDP_ENDIAN    PDP_ENDIAN
+
+#elif defined(__OpenBSD__)
+
+# include <sys/endian.h>
+
+#elif defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+
+# include <sys/endian.h>
+
+# define be16toh(x) betoh16(x)
+# define le16toh(x) letoh16(x)
+
+# define be32toh(x) betoh32(x)
+# define le32toh(x) letoh32(x)
+
+# define be64toh(x) betoh64(x)
+# define le64toh(x) letoh64(x)
+
+#elif defined(__WINDOWS__)
+
+# include <winsock2.h>
+# include <sys/param.h>
+
+# if BYTE_ORDER == LITTLE_ENDIAN
+
+#   define htobe16(x) htons(x)
+#   define htole16(x) (x)
+#   define be16toh(x) ntohs(x)
+#   define le16toh(x) (x)
+ 
+#   define htobe32(x) htonl(x)
+#   define htole32(x) (x)
+#   define be32toh(x) ntohl(x)
+#   define le32toh(x) (x)
+ 
+#   define htobe64(x) htonll(x)
+#   define htole64(x) (x)
+#   define be64toh(x) ntohll(x)
+#   define le64toh(x) (x)
+
+# elif BYTE_ORDER == BIG_ENDIAN
+
+    /* that would be xbox 360 */
+#   define htobe16(x) (x)
+#   define htole16(x) __builtin_bswap16(x)
+#   define be16toh(x) (x)
+#   define le16toh(x) __builtin_bswap16(x)
+ 
+#   define htobe32(x) (x)
+#   define htole32(x) __builtin_bswap32(x)
+#   define be32toh(x) (x)
+#   define le32toh(x) __builtin_bswap32(x)
+ 
+#   define htobe64(x) (x)
+#   define htole64(x) __builtin_bswap64(x)
+#   define be64toh(x) (x)
+#   define le64toh(x) __builtin_bswap64(x)
+
+# else
+
+#   error byte order not supported
+
+# endif
+
+# define __BYTE_ORDER    BYTE_ORDER
+# define __BIG_ENDIAN    BIG_ENDIAN
+# define __LITTLE_ENDIAN LITTLE_ENDIAN
+# define __PDP_ENDIAN    PDP_ENDIAN
+
+#else
+
+# error platform not supported
+
+#endif
+
+#endif

--- a/src/portable_endian.h
+++ b/src/portable_endian.h
@@ -12,6 +12,7 @@
 
 #if defined(__linux__) || defined(__CYGWIN__)
 
+# define __USE_BSD
 # include <endian.h>
 
 #elif defined(__APPLE__)

--- a/test/check_ahtable.c
+++ b/test/check_ahtable.c
@@ -203,6 +203,50 @@ void test_ahtable_sorted_iteration()
     fprintf(stderr, "done.\n");
 }
 
+void test_ahtable_save_load()
+{
+    fprintf(stderr, "saving ahtable ... \n");
+
+    FILE* fd_w = fopen("test.aht", "w");
+    ahtable_save(T, fd_w);
+    fclose(fd_w);
+
+    fprintf(stderr, "loading ahtable ... \n");
+
+    FILE* fd_r = fopen("test.aht", "r");
+    ahtable_t* U = ahtable_load(fd_r);
+    fclose(fd_r);
+
+    fprintf(stderr, "comparing ahtable ... \n");
+
+    ahtable_iter_t* i = ahtable_iter_begin(T, false);
+    ahtable_iter_t* j = ahtable_iter_begin(U, false);
+    const char *k1 = NULL;
+    const char *k2 = NULL;
+    value_t* v1;
+    value_t* v2;
+    size_t len1 = 0;
+    size_t len2 = 0;
+    while (!ahtable_iter_finished(i) && !ahtable_iter_finished(j)) {
+        k1 = ahtable_iter_key(i, &len1);
+        v1 = ahtable_iter_val(i);
+
+        k2 = ahtable_iter_key(j, &len2);
+        v2 = ahtable_iter_val(j);
+
+        if(len1 != len2) {
+            fprintf(stderr, "[error] key lengths don't match (%lu, %lu)\n", len1, len2);
+        }
+
+        if(*v1 != *v2) {
+            fprintf(stderr, "[error] values don't match (%lu, %lu)\n", *v1, *v2);
+        }
+
+        ahtable_iter_next(i);
+    }
+    ahtable_iter_free(i);
+}
+
 
 int main()
 {
@@ -214,6 +258,11 @@ int main()
     setup();
     test_ahtable_insert();
     test_ahtable_sorted_iteration();
+    teardown();
+
+    setup();
+    test_ahtable_insert();
+    test_ahtable_save_load();
     teardown();
 
     return 0;

--- a/test/check_ahtable.c
+++ b/test/check_ahtable.c
@@ -243,8 +243,10 @@ void test_ahtable_save_load()
         }
 
         ahtable_iter_next(i);
+        ahtable_iter_next(j);
     }
     ahtable_iter_free(i);
+    ahtable_iter_free(j);
 }
 
 


### PR DESCRIPTION
Adds the ability to load and save an ahtable object in architecture-agnostic way (uses 64-bit values where there is ambiguity).

I sent an earlier version of this pull request to luikore, but since we're merging code bases, I thought it made the most sense to start work on the main repository.
