### PR TITLE
Add hattrie_size function to get number of keys in trie

### DIFF
--- a/src/hat-trie.c
+++ b/src/hat-trie.c
@@ -154,6 +154,10 @@ hattrie_t* hattrie_create()
     return T;
 }
 
+size_t hattrie_size(hattrie_t* T)
+{
+    return T->m;
+}
 
 static void hattrie_free_node(node_ptr node)
 {

--- a/src/hat-trie.h
+++ b/src/hat-trie.h
@@ -33,6 +33,7 @@ void       hattrie_free   (hattrie_t*);       //< Free all memory used by a trie
 hattrie_t* hattrie_dup    (const hattrie_t*); //< Duplicate an existing trie.
 void       hattrie_clear  (hattrie_t*);       //< Remove all entries.
 
+size_t     hattrie_size(hattrie_t* T);
 
 /** Find the given key in the trie, inserting it if it does not exist, and
  * returning a pointer to it's key.


### PR DESCRIPTION
Accessor function so that outside code doesn't need to know about hattrie_t internals
