### PR TITLE
fix for running tests in an out-of-source build

### DIFF
--- a/test/Makefile.am
+++ b/test/Makefile.am
@@ -4,12 +4,12 @@ check_PROGRAMS = check_ahtable check_hattrie bench_sorted_iter
 
 check_ahtable_SOURCES  = check_ahtable.c str_map.c
 check_ahtable_LDADD    = $(top_builddir)/src/libhat-trie.la
-check_ahtable_CPPFLAGS = -I$(top_builddir)/src
+check_ahtable_CPPFLAGS = -I$(top_srcdir)/src
 
 check_hattrie_SOURCES  = check_hattrie.c str_map.c
 check_hattrie_LDADD    = $(top_builddir)/src/libhat-trie.la
-check_hattrie_CPPFLAGS = -I$(top_builddir)/src
+check_hattrie_CPPFLAGS = -I$(top_srcdir)/src
 
 bench_sorted_iter_SOURCES  = bench_sorted_iter.c
 bench_sorted_iter_LDADD    = $(top_builddir)/src/libhat-trie.la
-bench_sorted_iter_CPPFLAGS = -I$(top_builddir)/src
+bench_sorted_iter_CPPFLAGS = -I$(top_srcdir)/src


### PR DESCRIPTION
Just a small thing to have proper out-of-source builds. tested with gcc-10.2.0 and clang 10.0.1